### PR TITLE
Set env vars for pytest

### DIFF
--- a/roles/thoth-pytest/tasks/main.yaml
+++ b/roles/thoth-pytest/tasks/main.yaml
@@ -4,7 +4,7 @@
 
 - name: "pip and pipenv version"
   command: "pipenv --version"
-      
+
 - name: "install requirments via pipenv"
   command: "pipenv install --dev"
   args:
@@ -18,3 +18,4 @@
   command: "pipenv run python3 setup.py test"
   args:
     chdir: "{{ zuul.project.src_dir }}"
+  environment: "{{ zuul.project.vars }}"


### PR DESCRIPTION
Set env vars for pytest
Related-to: 
https://github.com/thoth-station/zuul-config/issues/87
https://github.com/AICoE/prometheus-api-client-python/pull/58
https://github.com/AICoE/prometheus-api-client-python/pull/63

References:
https://zuul-ci.org/docs/zuul/user/jobs.html#project-variables
https://zuul-ci.org/docs/zuul/user/config.html#attr-project.vars

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>