### PR TITLE
fixing variable name zuul.project.vars->project.vars

### DIFF
--- a/roles/thoth-pytest/tasks/main.yaml
+++ b/roles/thoth-pytest/tasks/main.yaml
@@ -18,4 +18,4 @@
   command: "pipenv run python3 setup.py test"
   args:
     chdir: "{{ zuul.project.src_dir }}"
-  environment: "{{ zuul.project.vars }}"
+  environment: "{{ project.vars }}"


### PR DESCRIPTION
fixing variable name zuul.project.vars->project.vars
zuul.project doesnt have vars, the are vars variable is present in project, according to the documentation.
Related-To: #27 
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>