### PR TITLE
fixing variable name project.vars-> hostvars.project.vars

### DIFF
--- a/roles/thoth-pytest/tasks/main.yaml
+++ b/roles/thoth-pytest/tasks/main.yaml
@@ -18,4 +18,4 @@
   command: "pipenv run python3 setup.py test"
   args:
     chdir: "{{ zuul.project.src_dir }}"
-  environment: "{{ project.vars }}"
+  environment: "{{ hostvars.project.vars }}"


### PR DESCRIPTION
fixing variable name project.vars-> hostvars.project.vars
Debugging is still going on.
Related-to: #28 #27 
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>