### PR TITLE
fixing environment variable used by pytest

### DIFF
--- a/roles/thoth-pytest/tasks/main.yaml
+++ b/roles/thoth-pytest/tasks/main.yaml
@@ -15,9 +15,10 @@
     PIPENV_COLORBLIND: "1"
 
 - name: "debugging vars"
-  debug: var=hostvars
+  debug: var=hostvars["pod"]
 
 - name: "run pytest"
   command: "pipenv run python3 setup.py test"
   args:
     chdir: "{{ zuul.project.src_dir }}"
+  environment: "{{ hostvars }}"


### PR DESCRIPTION
fixing environment variable used by pytest

Second last debugging try :sweat_smile: 

Related-to: #30 
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
