### PR TITLE
Fixed environment variable used by pytest

### DIFF
--- a/roles/thoth-pytest/tasks/main.yaml
+++ b/roles/thoth-pytest/tasks/main.yaml
@@ -14,11 +14,8 @@
     PIPENV_HIDE_EMOJIS: "1"
     PIPENV_COLORBLIND: "1"
 
-- name: "debugging vars"
-  debug: var=hostvars["pod"]
-
 - name: "run pytest"
   command: "pipenv run python3 setup.py test"
   args:
     chdir: "{{ zuul.project.src_dir }}"
-  environment: "{{ hostvars }}"
+  environment: "{{ hostvars.pod }}"


### PR DESCRIPTION
Fixed environment variable used by pytest
Fixes: #30 

Zuul project vars and jobs vars are present in hostvars of ansible.
Using hostvars.pod we can get all the variable including the job vars and project vars.
Explicitly getting these variables in general case is not convenient.
Passing all the vars to Pytest environment. Hence env var pytest can be placed in job variable or pytest variable. 


Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
