### PR TITLE
Removed virtualenv from pytest

### DIFF
--- a/roles/thoth-pytest/tasks/main.yaml
+++ b/roles/thoth-pytest/tasks/main.yaml
@@ -5,9 +5,6 @@
 - name: "micropipenv version"
   command: "micropipenv --version"
 
-- name: "create a virtual environment"
-  command: "python3 -m venv venv/ && . venv/bin/activate"
-
 - name: "install requirments via micropipenv"
   command: "micropipenv install --dev"
   args:


### PR DESCRIPTION
Removed virtualenv from pytest.
```
python3 -m venv venv/ && . venv/bin/activate
non-zero return code
Error: Unable to create directory '/tmp/venv/bin/activate'
```
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>