### PR TITLE
Zuul support for python3.7 pytest

### DIFF
--- a/zuul.d/jobs-thoth.yaml
+++ b/zuul.d/jobs-thoth.yaml
@@ -26,6 +26,15 @@
     run: playbooks/thoth/pytest.yaml
 
 - job:
+    name: thoth-pytest-py37
+    parent: base-openshift-pod
+    nodeset:
+      nodes:
+        - name: pod
+          label: thoth-pytest-py37
+    run: playbooks/thoth/pytest.yaml
+
+- job:
     name: "thoth-behave"
     parent: "base-openshift-pod"
     description: |


### PR DESCRIPTION
Zuul support for python3.7 pytest
Depends-On: https://github.com/thoth-station/zuul-infra/pull/21
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>